### PR TITLE
feat: Retry in more failing scenarios

### DIFF
--- a/lib/send.js
+++ b/lib/send.js
@@ -4,14 +4,17 @@ const https = require('https')
 const http = require('http')
 const concat = require('concat-stream')
 const url = require('url')
+const once = require('once')
+
 const MAX_ATTEMPTS = 5
-const RETRY_INTERVAL = process.env.BUGSNAG_RETRY_INTERVAL || 1000
+const RETRY_INTERVAL = parseInt(process.env.BUGSNAG_RETRY_INTERVAL) || 1000
+const TIMEOUT = parseInt(process.env.BUGSNAG_TIMEOUT) || 30000
 
 module.exports = (endpoint, data, onSuccess, onError) => {
   let attempts = 0
   const maybeRetry = (err) => {
     attempts++
-    if (err && err.isRetryable && attempts < MAX_ATTEMPTS) return setTimeout(go, RETRY_INTERVAL)
+    if (err && err.isRetryable !== false && attempts < MAX_ATTEMPTS) return setTimeout(go, RETRY_INTERVAL)
     return onError(err)
   }
   const go = () => send(endpoint, data, onSuccess, maybeRetry)
@@ -19,6 +22,7 @@ module.exports = (endpoint, data, onSuccess, onError) => {
 }
 
 const send = (endpoint, data, onSuccess, onError) => {
+  onError = once(onError)
   const parsedUrl = url.parse(endpoint)
   const payload = JSON.stringify(data)
   const req = (parsedUrl.protocol === 'https:' ? https : http).request({
@@ -35,12 +39,16 @@ const send = (endpoint, data, onSuccess, onError) => {
       if (res.statusCode === 200) return onSuccess()
       if (res.statusCode !== 400) {
         const err = new Error(`HTTP status ${res.statusCode} received from builds API`)
-        err.isRetryable = true
+        if (!isRetryable(res.statusCode)) {
+          err.isRetryable = false
+        }
         return onError(err)
       }
       try {
         const err = new Error('Invalid payload sent to builds API')
         err.errors = JSON.parse(body).errors
+        // never retry a 400
+        err.isRetryable = false
         return onError(err)
       } catch (e) {
         return onError(new Error(`HTTP status ${res.statusCode} received from builds API`))
@@ -49,5 +57,19 @@ const send = (endpoint, data, onSuccess, onError) => {
   })
   req.on('error', onError)
   req.write(payload)
+  req.setTimeout(TIMEOUT, () => {
+    onError(new Error('Connection timed out'))
+    req.abort()
+  })
   req.end()
+}
+
+const isRetryable = status => {
+  return (
+    status < 400 ||
+    status > 499 ||
+    [
+      408, // timeout
+      429 // too many requests
+    ].indexOf(status) !== -1)
 }

--- a/lib/send.js
+++ b/lib/send.js
@@ -50,8 +50,10 @@ const send = (endpoint, data, onSuccess, onError) => {
         // never retry a 400
         err.isRetryable = false
         return onError(err)
-      } catch (e) {
-        return onError(new Error(`HTTP status ${res.statusCode} received from builds API`))
+      } catch (_) {
+        const e = new Error(`HTTP status ${res.statusCode} received from builds API`)
+        e.isRetryable = false
+        return onError(e)
       }
     }))
   })

--- a/lib/test/send.test.js
+++ b/lib/test/send.test.js
@@ -119,8 +119,10 @@ test('send(): unsuccessful, doesn’t retry (400)', t => {
 })
 
 test('send(): unsuccessful (400, bad json)', t => {
-  t.plan(2)
+  t.plan(3)
+  let n = 0
   const server = http.createServer((req, res) => {
+    n++
     res.statusCode = 400
     res.setHeader('content-type', 'application/json')
     res.end('{ "err')
@@ -133,6 +135,7 @@ test('send(): unsuccessful (400, bad json)', t => {
     server.close()
     t.ok(err)
     t.equal(err.message, 'HTTP status 400 received from builds API')
+    t.equal(n, 1)
     t.end()
   })
 })

--- a/lib/test/send.test.js
+++ b/lib/test/send.test.js
@@ -1,9 +1,11 @@
 'use strict'
 
 process.env.BUGSNAG_RETRY_INTERVAL = 50
+process.env.BUGSNAG_TIMEOUT = 100
 
 const test = require('tape')
 const http = require('http')
+const net = require('net')
 const send = require('../send')
 
 test('send(): successful', t => {
@@ -131,6 +133,46 @@ test('send(): unsuccessful (400, bad json)', t => {
     server.close()
     t.ok(err)
     t.equal(err.message, 'HTTP status 400 received from builds API')
+    t.end()
+  })
+})
+
+test('send(): retry on timeouts', t => {
+  t.plan(3)
+  let n = 0
+  const server = net.createServer((req, res) => {
+    n++
+  })
+  server.listen()
+  send(`http://localhost:${server.address().port}`, {}, () => {
+    server.close()
+    t.fail('send should not succeed')
+  }, (err) => {
+    server.close()
+    t.equal(n, 5, 'should retry after timeouts')
+    t.ok(err)
+    t.equal(err.message, 'Connection timed out')
+    t.end()
+  })
+})
+
+test('send(): retry on socket hangups', t => {
+  t.plan(4)
+  let n = 0
+  const server = http.createServer((req, res) => {
+    n++
+    req.connection.end()
+  })
+  server.listen()
+  send(`http://localhost:${server.address().port}`, {}, () => {
+    server.close()
+    t.fail('send should not succeed')
+  }, (err) => {
+    server.close()
+    t.equal(n, 5, 'should retry after timeouts')
+    t.ok(err)
+    t.equal(err.code, 'ECONNRESET')
+    t.equal(err.message, 'socket hang up')
     t.end()
   })
 })

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "bugsnag-build-reporter",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
     "find-nearest-file": "^1.1.0",
     "meow": "^4.0.0",
     "minimist": "^1.2.0",
+    "once": "^1.4.0",
     "pino": "^4.10.3",
     "run-parallel": "^1.1.6"
   }


### PR DESCRIPTION
Requests are now retried unless deemed not-retryable, so now transient network issues such as socket timeouts and socket hang ups are tolerated.