### PR TITLE
explicitly get origin url

### DIFF
--- a/lib/source-control.js
+++ b/lib/source-control.js
@@ -80,11 +80,11 @@ const detectSourceInfoFromRepo = (path, log, cb) => {
 const detectSourceInfoFromGit = (cwd, cb) => {
   parallel([
     cb => exec('git rev-parse HEAD', { cwd }, cb),
-    cb => exec('git remote -v', { cwd }, cb)
+    cb => exec('git remote get-url origin', { cwd }, cb)
   ], (err, data) => {
     cb(err, {
       revision: data[0] ? data[0].trim() : null,
-      repository: data[1] ? data[1].split(/\t|\s|\n/)[1] : null
+      repository: data[1] ? data[1].trim() : null
     })
   })
 }


### PR DESCRIPTION
I noticed this was failing when I had another remote named _Heroku_. Changed it to explicitly grab the URL for origin.