### PR TITLE
Source control: prefer remote named "origin"

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,6 @@
 language: node_js
 node_js:
-  - "4"
   - "6"
   - "8"
+  - "10"
+  - "12"

--- a/lib/source-control.js
+++ b/lib/source-control.js
@@ -80,11 +80,11 @@ const detectSourceInfoFromRepo = (path, log, cb) => {
 const detectSourceInfoFromGit = (cwd, cb) => {
   parallel([
     cb => exec('git rev-parse HEAD', { cwd }, cb),
-    cb => exec('git remote -v', { cwd }, cb)
+    cb => exec('git remote get-url origin', { cwd }, cb)
   ], (err, data) => {
     cb(err, {
       revision: data[0] ? data[0].trim() : null,
-      repository: data[1] ? data[1].split(/\t|\s|\n/)[1] : null
+      repository: data[1] ? data[1].trim() : null
     })
   })
 }

--- a/lib/source-control.js
+++ b/lib/source-control.js
@@ -80,11 +80,18 @@ const detectSourceInfoFromRepo = (path, log, cb) => {
 const detectSourceInfoFromGit = (cwd, cb) => {
   parallel([
     cb => exec('git rev-parse HEAD', { cwd }, cb),
-    cb => exec('git remote get-url origin', { cwd }, cb)
+    cb => {
+      // eslint-disable-next-line
+      exec('git remote get-url origin', { cwd }, (err, data) => {
+        // ignore this error in case origin doesn't exist
+        cb(null, data)
+      })
+    },
+    cb => exec('git remote -v', { cwd }, cb)
   ], (err, data) => {
     cb(err, {
       revision: data[0] ? data[0].trim() : null,
-      repository: data[1] ? data[1].trim() : null
+      repository: data[1] ? data[1].trim() : (data[2] ? data[2].split(/\t|\s|\n/)[1] : null)
     })
   })
 }


### PR DESCRIPTION
This update includes a contribution from @marktran (thanks Mark!) to select the url from the remote named `origin` when attemping to detect the git repo URL. Previously it would just choose the first remote from the list output by `git remote -v`, which lists in alphabetical order.

Since the command `git remote get-url <name> ` will error if the provided remote does not exist, I added a fallback to the original logic.