### PR TITLE
docs: Update travis badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # bugsnag-build-reporter
-[![Build status](https://travis-ci.org/bugsnag/bugsnag-build-reporter-node.svg?branch=master)](https://travis-ci.org/bugsnag/bugsnag-build-reporter-node)
+[![Build status](https://travis-ci.com/bugsnag/bugsnag-build-reporter-node.svg?branch=master)](https://travis-ci.com/bugsnag/bugsnag-build-reporter-node)
 [![NPM](https://img.shields.io/npm/v/bugsnag-build-reporter.svg)](https://npmjs.org/package/bugsnag-build-reporter)
 
 A tool for reporting your application's builds to Bugsnag. It can auto detect source control from `.git`, `.hg` and `package.json`.


### PR DESCRIPTION
Travis now runs on .com not .org