### PR TITLE
Bump Minimist Library Version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1401,9 +1401,9 @@
       }
     },
     "minimist": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
-      "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ="
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
+      "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw=="
     },
     "minimist-options": {
       "version": "3.0.2",
@@ -1511,6 +1511,7 @@
           "version": "0.1.4",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "kind-of": "^3.0.2",
             "longest": "^1.0.1",
@@ -2321,7 +2322,8 @@
         "longest": {
           "version": "1.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "loose-envify": {
           "version": "1.3.1",

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "concat-stream": "^1.6.0",
     "find-nearest-file": "^1.1.0",
     "meow": "^4.0.0",
-    "minimist": "^1.2.0",
+    "minimist": "^1.2.3",
     "once": "^1.4.0",
     "pino": "^4.10.3",
     "run-parallel": "^1.1.6"

--- a/package.json
+++ b/package.json
@@ -33,7 +33,6 @@
     "concat-stream": "^1.6.0",
     "find-nearest-file": "^1.1.0",
     "meow": "^4.0.0",
-    "minimist": "^1.2.3",
     "once": "^1.4.0",
     "pino": "^4.10.3",
     "run-parallel": "^1.1.6"


### PR DESCRIPTION
## Goal

Minimist version 1.2.0 introduced code that makes the package vulnerable to Prototype Pollution.  The library recommends that all users switch to version 1.2.3: https://www.npmjs.com/package/minimist#security

## Design

This design was used to fix a security issue.

## Changeset

Just bumps the version for `minimist` to 1.2.3 from 1.2

## Testing

I ran `npm test` and the output with `minimist` at 1.2 matches the output with it at `1.2.3`.