### PR TITLE
fix: vulnerable package (high) Regular Expression Denial of Service

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "chalk": "^2.3.0",
     "concat-stream": "^1.6.0",
     "find-nearest-file": "^1.1.0",
-    "meow": "^4.0.0",
+    "meow": "^10.0.1",
     "once": "^1.4.0",
     "pino": "^4.10.3",
     "run-parallel": "^1.1.6"


### PR DESCRIPTION
High vulnerability detected in `webpack-bugsnag-plugins` with this path:

`webpack-bugsnag-plugins` > `bugsnag-build-reporter` > `meow` > `trim-newlines`

The offending package is `trim-newlines`, which is fixed in `>=4.0.1`. You can see the advisory here:
- https://www.npmjs.com/advisories/1753

Bumping `meow` resolves the issue. I have not tested this change