### PR TITLE
Fix typo in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ Then use like so:
 const reportBuild = require('bugsnag-build-reporter')
 reportBuild({ apiKey: 'YOUR_API_KEY', appVersion: '1.2.3' }, { /* opts */ })
   .then(() => console.log('success!'))
-  .catch(err => console.log('fail', err.messsage))
+  .catch(err => console.log('fail', err.message))
 ```
 
 ##### `reportBuild(build: object, opts: object) => Promise`


### PR DESCRIPTION
## Goal

<!-- Why is this change necessary? -->
There is a typo in the copypaste JS API code in the README which will break if someone copies and uses it.

## Design

<!-- Why was this approach used? -->
N/A

## Changeset

<!-- What changed? -->
Fix README typo

## Testing

<!-- How was it tested? What manual and automated tests were
     run/added? -->
N/A